### PR TITLE
fixed deprecated use of CallbackBase

### DIFF
--- a/human_log.py
+++ b/human_log.py
@@ -17,6 +17,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.plugins.callback import CallbackBase
+
 import sys
 reload(sys)
 sys.setdefaultencoding('utf-8')
@@ -31,7 +33,7 @@ FIELDS = ['cmd', 'command', 'start', 'end', 'delta', 'msg', 'stdout',
           'stderr', 'results']
 
 
-class CallbackModule(object):
+class CallbackModule(CallbackBase):
 
     """
     Ansible callback plugin for human-readable result logging


### PR DESCRIPTION
I don't know if anyone is using and or maintaining this anymore, but here is a small fix as discussed in this thread: https://github.com/ansible/ansible/issues/30597

cheers